### PR TITLE
Add support of new GetSystemTime RPC

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -397,7 +397,8 @@ SDL.SDLController = Em.Object.extend(
       );
     },
     /**
-     * Notify SDLCore that HMI is ready and all components are registered
+     * Notify SDLCore that HMI is ready and all components are registered.
+     * Also notify SDLCore that HMI is ready to provide system time.
      *
      * @type {String}
      */
@@ -409,6 +410,7 @@ SDL.SDLController = Em.Object.extend(
         }
       }
       FFW.BasicCommunication.onReady();
+      FFW.BasicCommunication.onSystemTimeReady();
     }.observes('SDL.SDLModel.data.registeredComponents.@each.state'),
     /**
      * Show VrHelpItems popup with necessary params

--- a/app/controller/sdl/RPCController.js
+++ b/app/controller/sdl/RPCController.js
@@ -405,6 +405,18 @@ SDL.RPCController = Em.Object.create(
           return this.resultStruct;
         },
         /**
+         * Validate method for request GetSystemTime
+         *
+         * @param {Object}
+         *            params
+         */
+        GetSystemTime : function(params) {
+          this.resultStruct = {
+            'resultCode' : SDL.SDLModel.data.resultCode.SUCCESS
+          };
+          return this.resultStruct;
+        },
+        /**
          * Validate method for request GetSystemInfo
          *
          * @param {Object}

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -379,6 +379,9 @@ FFW.BasicCommunication = FFW.RPCObserver
           if (request.method == 'BasicCommunication.AllowDeviceToConnect') {
             this.AllowDeviceToConnect(request.id, request.method, true);
           }
+          if (request.method == 'BasicCommunication.GetSystemTime') {
+            this.GetSystemTime(request.id, request.method);
+          }
           if (request.method == 'BasicCommunication.UpdateDeviceList') {
             SDL.SDLModel.onGetDeviceList(request.params);
             this.sendBCResult(
@@ -729,6 +732,44 @@ FFW.BasicCommunication = FFW.RPCObserver
         this.client.send(JSONMessage);
       },
       /**
+       * Response with current system UTC time
+       *
+       * @param {Number}
+       *            id
+       * @param {String}
+       *            method
+       */
+      GetSystemTime : function(id, method) {
+        Em.Logger.log('FFW.' + method + ' Response');
+
+        var current_time = new Date;
+        var system_time_utc = {
+          'second' : current_time.getUTCSeconds(),
+          'minute' : current_time.getUTCMinutes(),
+          'hour' : current_time.getUTCHours(),
+          'day' : current_time.getUTCDate(),
+          'month' : current_time.getUTCMonth(),
+          'year' : current_time.getUTCFullYear(),
+
+          // According to APPLINK-33109 fields below should be set to 0
+          'millisecond' : 0,
+          'tz_hour' : 0,
+          'tz_minute' : 0
+        };
+
+        // Send repsonse
+        var JSONMessage = {
+          'jsonrpc' : '2.0',
+          'id' : id,
+          'result' : {
+            'code' : SDL.SDLModel.data.resultCode.SUCCESS,
+            'method' : method,
+            'systemTime' : system_time_utc
+          }
+        };
+        this.client.send(JSONMessage);
+      },
+      /**
        * Response with params of the last one supports mixing audio (ie
        * recording TTS command and playing audio).
        *
@@ -798,6 +839,7 @@ FFW.BasicCommunication = FFW.RPCObserver
         };
         this.client.send(JSONMessage);
       },
+
       /********************* Responses end *********************/
 
       /********************* Notifications BEGIN *********************/
@@ -889,7 +931,7 @@ FFW.BasicCommunication = FFW.RPCObserver
         this.client.send(JSONMessage);
       },
       /**
-       * notification that UI is ready BasicCommunication should be sunscribed
+       * notification that UI is ready BasicCommunication should be subscribed
        * to this notification
        */
       onReady: function() {
@@ -897,6 +939,18 @@ FFW.BasicCommunication = FFW.RPCObserver
         var JSONMessage = {
           'jsonrpc': '2.0',
           'method': 'BasicCommunication.OnReady'
+        };
+        this.client.send(JSONMessage);
+      },
+      /**
+       * notify SDL about readiness to provide system time.
+       * BasicCommunication should be subscribed to this notification
+       */
+      onSystemTimeReady : function() {
+        Em.Logger.log('FFW.BasicCommunication.onSystemTimeReady');
+        var JSONMessage = {
+          'jsonrpc' : '2.0',
+          'method' : 'BasicCommunication.OnSystemTimeReady'
         };
         this.client.send(JSONMessage);
       },


### PR DESCRIPTION
Added implementation of onSystemTimeReady().
Added onSystemTimeReady notification right after onReady().
Added implemetation of GetSystemTime() to response on approriate SDL request.

Related tasks : [APPLINK-29396](https://adc.luxoft.com/jira/browse/APPLINK-29396), [APPLINK-29386](https://adc.luxoft.com/jira/browse/APPLINK-29386)