### PR TITLE
Fix month value in GetSystemTime response

### DIFF
--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -748,7 +748,8 @@ FFW.BasicCommunication = FFW.RPCObserver
           'minute' : current_time.getUTCMinutes(),
           'hour' : current_time.getUTCHours(),
           'day' : current_time.getUTCDate(),
-          'month' : current_time.getUTCMonth(),
+          // According to APPLINK-21928 month should be in range 1..12
+          'month' : current_time.getUTCMonth() + 1,
           'year' : current_time.getUTCFullYear(),
 
           // According to APPLINK-33109 fields below should be set to 0


### PR DESCRIPTION
Fixed value in systemTime->month field in GetSystemTime request.
Function [getUTCMonth()](https://www.w3schools.com/jsref/jsref_getutcmonth.asp) returns month value in range 0..11. But according to HMI_API it should be 1..12. This fix resolves this problem.

Related tasks: [APPLINK-33391](https://adc.luxoft.com/jira/browse/APPLINK-33391)